### PR TITLE
feat: Add appointment completion functionality

### DIFF
--- a/app/Http/Controllers/Api/AppointmentController.php
+++ b/app/Http/Controllers/Api/AppointmentController.php
@@ -95,4 +95,31 @@ class AppointmentController extends Controller
         $appointments = auth()->user()->appointments()->with('healthcareProfessional')->get();
         return response()->json(['status' => true, 'message' => "Appointment List", 'result' => $appointments]);
     }
+
+    /**
+     * Mark an appointment as completed.
+     *
+     * @param int $id The ID of the appointment to mark as complete
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function complete($id)
+    {
+        try {
+            // Assume only a healthcare professional can complete an appointment
+            $user = auth()->user();
+
+            $response = $this->appointmentService->completeAppointment($id, $user->id);
+
+            return response()->json([
+                'status' => $response['status'],
+                'message' => $response['message']
+            ], $response['code']);
+
+        } catch (\Exception $e) {
+            return response()->json([
+                'status' => false,
+                'message' => 'Something went wrong.'
+            ], 500);
+        }
+    }
 }

--- a/app/Services/AppointmentService.php
+++ b/app/Services/AppointmentService.php
@@ -127,4 +127,38 @@ class AppointmentService
             ];
         }
     }
+
+    /**
+     * Mark a specific appointment as completed.
+     *
+     * @param int $appointmentId The ID of the appointment
+     * @param int $professionalId The ID of the professional completing the appointment
+     * @return array
+     */
+    public function completeAppointment($appointmentId, $userId)
+    {
+        $appointment = Appointment::find($appointmentId);
+
+        if (!$appointment) {
+            return ['status' => false, 'message' => 'Appointment not found.', 'code' => 404];
+        }
+
+        // Ensure the appointment belongs to the professional
+        if ($appointment->user_id !== $userId) {
+            return ['status' => false, 'message' => 'Unauthorized to complete this appointment.', 'code' => 403];
+        }
+
+        // Ensure the appointment is not already completed or cancelled
+        if ($appointment->status === 'completed' || $appointment->status === 'cancelled') {
+            return ['status' => false, 'message' => 'Appointment is already completed or cancelled.', 'code' => 409];
+        }
+
+        // Update the status and completed_at timestamp
+        $appointment->status = 'completed';
+        $appointment->completed_at = Carbon::now();
+        $appointment->save();
+
+        return ['status' => true, 'message' => 'Appointment marked as completed.', 'code' => 200];
+    }
+
 }

--- a/database/migrations/2025_08_24_104204_add_completed_at_to_appointments_table.php
+++ b/database/migrations/2025_08_24_104204_add_completed_at_to_appointments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->timestamp('completed_at')->nullable()->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->dropColumn('completed_at');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,7 @@ Route::middleware('auth:api')->group(function () {
     Route::post('/appointments', [AppointmentController::class, 'book']);
     Route::get('/appointments', [AppointmentController::class, 'myAppointments']);
     Route::delete('/appointments/{id}', [AppointmentController::class, 'cancel']);
+    Route::put('/appointments/{id}/complete', [AppointmentController::class, 'complete']);
 });
 
 Route::get('/user', function (Request $request) {


### PR DESCRIPTION
This commit introduces a new feature that allows healthcare professionals to mark an appointment as completed.

- **API Endpoint:** A new `PUT` route at `/api/appointments/{id}/complete` was added.
- **Controller & Service Logic:** A `complete` method was implemented in `AppointmentController` to validate the user and call the `completeAppointment` method in `AppointmentService`. The service handles updating the appointment's status to `completed`.
- **Database Schema:** A nullable `completed_at` timestamp column was added to the `appointments` table via a new migration to track the time of completion.

This functionality improves the application's ability to track the full lifecycle of an appointment.